### PR TITLE
Use Specific Error Types

### DIFF
--- a/generate-map.py
+++ b/generate-map.py
@@ -21,7 +21,7 @@ def load_datafile():
         with open("cache.json", "r") as data_file:
             data = data_file.read()
             data = json.loads(data)
-    except Exception:
+    except FileNotFoundError:
         with open("cache.json", "w+") as data_file:
             # Because of the empty file python converts data to a String, so
             # in line 46 append is not working.


### PR DESCRIPTION
Use specific error types to catch errors you expect but still fail early
if there is an actual error. This patch still handles a non-existing
cache file which is an expected error but it does not handle other
errors (e.g. permission errors) which would likely cause problems later
anyway.